### PR TITLE
More variables to the calculation price formula

### DIFF
--- a/src/defaults.lua
+++ b/src/defaults.lua
@@ -61,6 +61,36 @@ function QuickApp:setDefaultVariables()
         self:setVariable(self.variable_tax_percentage_name, self.tax)
     end
     
+     -- Set local variable operator
+    if self.operator == nil or self.operator == "" then
+        self.operator = self.default_operator_cost
+        self:setVariable(self.variable_operator_cost_name, self.operator)
+    end
+
+-- Set local variable losses
+    if self.losses == nil or self.losses == "" then
+        self.losses = self.default_grid_losses
+        self:setVariable(self.variable_grid_losses_name, self.losses)
+    end
+
+-- Set local variable adjustment
+    if self.adjustment == nil or self.adjustment == "" then
+        self.adjustment = self.default_adjustment
+        self:setVariable(self.variable_adjustment_name, self.adjustment)
+    end
+
+-- Set local variable dealer
+    if self.dealer == nil or self.dealer == "" then
+        self.dealer = self.default_dealer_cost
+        self:setVariable(self.variable_dealer_cost_name, self.dealer)
+    end
+
+-- Set local variable grid
+    if self.grid == nil or self.grid == "" then
+        self.grid = self.default_grid_cost
+        self:setVariable(self.variable_grid_cost_name, self.grid)
+    end
+    
     -- Set local variable Days to keep FIBARO Tariff history
     if self.tariffHistory == nil or self.tariffHistory == "" then
         self.tariffHistory = self.default_tariff_history
@@ -97,6 +127,11 @@ function QuickApp:refreshVariables()
     self.veryhigh_price = tonumber(self:getVariable(self.variable_VeryHigh_name))
     self.areaCode = self:getAreaCode(self.areaName)
     self.tax = tonumber(self:getVariable(self.variable_tax_percentage_name))
+    self.operator = tonumber(self:getVariable(self.variable_operator_cost_name))
+    self.losses = tonumber(self:getVariable(self.variable_grid_losses_name))
+    self.adjustment = tonumber(self:getVariable(self.variable_adjustment_name))
+    self.dealer = tonumber(self:getVariable(self.variable_dealer_cost_name))
+    self.grid = tonumber(self:getVariable(self.variable_grid_cost_name))
     self.areaName = fibaro.getGlobalVariable(self.global_var_area_name)
     self.unit = fibaro.getGlobalVariable(self.global_var_unit_name)
 

--- a/src/fibaroTariffRate.lua
+++ b/src/fibaroTariffRate.lua
@@ -22,7 +22,7 @@ function QuickApp:updateFibaroTariffTable(energyRateTable)
     local totalRate = 0;
     for index, rateData in pairs(energyRateTable) do
         local tariffName = self:getRateDate(rateData.rateDate, "%Y-%m-%d %H:%M", 0, self.timezoneOffset)
-        local calcRate = self:getLocalTariffRate(rateData.rate, self.exchangeRate, self.unit, self.tax)
+        local calcRate = self:getLocalTariffRate(rateData.rate, self.exchangeRate, self.unit, self.tax, self.operator, self.losses, self.adjustment, self.dealer, self.grid)
         totalRate = totalRate + calcRate
 
         if updateTariff or not (self:existsInFibaroTariffTable(addTariffs, tariffName)) then

--- a/src/functions.lua
+++ b/src/functions.lua
@@ -82,17 +82,24 @@ function QuickApp:xml2PriceTable(xml)
     return priceTable
 end
 
-function QuickApp:getLocalTariffRate(mainRate, exchangeRate, unit, tax)
+function QuickApp:getLocalTariffRate(mainRate, exchangeRate, unit, tax, operator, losses, adjustment, dealer, grid)
     if (exchangeRate == nil) then exchangeRate = 1 end
     if (tax == nil or tax == 0) then tax = 1 end
     if (tax > 1) then tax = (tax / 100) + 1 end -- Convert input tax in % to decimal if > 1
-
+    if (operator == nil) then operator = 0 end
+    if (losses == nil or losses == 0) then losses = 1 end
+    if (losses > 1) then losses = (losses / 100) + 1 end -- Convert input losses in % to decimal if > 1
+    if (adjustment == nil or adjustment == 0) then adjustment = 1 end
+    if (adjustment > 1) then adjustment = (adjustment / 100) + 1 end -- Convert input adjustment in % to decimal if > 1
+    if (dealer == nil) then dealer = 0 end
+    if (grid == nil) then grid = 0 end
+    
     -- Get Unit scale. ENTSO-e always return prices in €/MWh
     local unitScale = 1000 -- kWh
     if (unit == "MWh") then unitScale = 1 end 
     
     -- Recalculate main rate from EUR/mWh to {local currency}/kWh * tax
-    local rate = tonumber(string.format("%.2f",((tonumber(mainRate)*tonumber(exchangeRate)/unitScale)*tax)))
+    local rate = tonumber(string.format("%.2f",(((((tonumber(mainRate)*tonumber(exchangeRate)/unitScale)+operator)*losses*adjustment)+dealer+grid)*tax)))
     if rate <= 0 then rate = 0.00001 end -- FIBARO can't accept 0 or negative tariff rate price :(
     return rate
 end

--- a/src/main.lua
+++ b/src/main.lua
@@ -17,7 +17,7 @@
     v1.1 New feature release 2023-03
         - Keeps Tariff rate history in FIBARO.
         - Show more usefull info in QA panel.
-        - Add new global month avrage level variable "EnergyMonthLevel" for those that pay energy consumtion per month avrage.
+        - Add new global month avrage level variable "EnergyMonthLevel" for those that pay energy consumtion per month average.
         - Add new QA variable "TariffHistory" for how many days to store history in FIBARO tariff rates.
         - Localized panel text for language: EN, DK, NO, SV (if you want to help me with translation, please send me an email at energyrate@jamdata.com)
 
@@ -38,6 +38,9 @@
         - Move golbal variable "EnergyTaxPercentage" to local variable as "EnergyTax".
         - All the rate levels are now set as local variables.
         - Add translation in Portuguese (Thanks to Leandro C.)
+
+    v1.4(BETA)
+        - New variables to cost calculation formula: {[(ENTSO_cost + operator_cost) x losses x adjustment] + dealer + localgrid} x tax
 
 ]]
 
@@ -62,6 +65,11 @@ function QuickApp:onInit()
     self.default_Medium_price = self:getDefaultRatePrice(100)   -- Actual medium price based on local currency
     self.default_High_price = self:getDefaultRatePrice(180)     -- 180% of medium price based on local currency
     self.default_VeryHigh_price = self:getDefaultRatePrice(300) -- 300% of medium price based on local currency
+    self.default_operator_cost = "0"        -- Defult Grid Operator costs (0 €/kWh or 0 €/MWh)
+    self.default_grid_losses = "0"          -- Defult Grid Losses (0 %)
+    self.default_adjustment = "0"           -- Defult adjustment added to the Grid Losses (0 %)
+    self.default_dealer_cost = "0"          -- Dealer cost (0 €/KWh or 0 €/MWh)
+    self.default_grid_cost = "0"            -- Defult Local Grid cost (0 €/KWh or 0 €/MWh)
     self.nextday_releaseTime = 12      -- The UTC time of the day when ENTSO-e usually releses the next day prices
     self.child_rank_name = "ENTSO-e Next Energy Rate"
     self.next_rank_device_id = nil
@@ -72,6 +80,11 @@ function QuickApp:onInit()
     self.variable_High_name = "PriceHigh"
     self.variable_VeryHigh_name = "PriceVeryHigh"
     self.variable_tax_percentage_name = "EnergyTax"
+    self.variable_operator_cost_name = "Deviations"             -- Grid Operator costs (€/kWh or €/MWh)
+    self.variable_grid_losses_name = "GridLosses"               -- Grid Losses (%)
+    self.variable_adjustment_name = "Adjustment"                -- Adjustment added to the Grid Losses (%)
+    self.variable_dealer_cost_name = "DealerFee"                -- Dealer cost (€/KWh or €/MWh)
+    self.variable_grid_cost_name = "LocalGridTax"               -- Local Grid cost (€/KWh or €/MWh)
     self.global_var_unit_name = "EnergyUnit"
     self.global_var_area_name = "EnergyArea"    
     self.global_var_level_name = "EnergyHourLevel"


### PR DESCRIPTION
At least in Portugal some of the electrical energy dealer have a more complex formula to calculate the final cost billed to the user.
In my actual dealer ("Luzboa") to the ENTSO cost, there are some addings:

- Cost of the internacional electrical operator (4 €/MWh);
- Grid Losses (a variable table with 15 minutes interval previously define to the current year, but I can't find a API to get the value from, only an Excel with all year periods - the average for 2023 is 15%);
- An adjustment to the losses called "Suitability Factor) (2 %);

The cost above is the actual electric MWh cost. The dealer than adds it's fee (5 €/MWh in the "Luzboa" example) and in Portugal we have an additional tax from the local electric grid manager that is called "Taxa de Acesso às Redes" (network access cost) that is different if we are in Peak or Off-Peak hours (didn't introduce that diference yet), but introduced that factor on the formula (different periods to be think off later) that as for 2023 year a negativa value (because of all the economic crisis) with a value of -95,8 €/MWh to the user that don't have peak off-peak tariff (if we have different tariff for peak and off-peak the values are -84,2 €/MWh at peak time and -118,5 €/MWh at off-peak).

At the end the VAT added to the final MWh calculation.

The code changed that I suggest here intends to all this variables to the QA (local variables) and to the formula:

**Variable** - **meaning**
operator - cost of the international electrical operator (€/kWh or €/MWh)
losses - grid losses (%)
adjustment - suitability factor (%) added to the losses
dealer - national electric energy dealer fee (€/kWh or €/MWh)
grid - national network access cost (€/kWh or €/MWh)
